### PR TITLE
Update AmazonConnection.js

### DIFF
--- a/src/AmazonConnection.js
+++ b/src/AmazonConnection.js
@@ -6,7 +6,7 @@ const get = require('lodash.get')
 class AmazonConnection extends Connection {
   constructor (options) {
     super(options)
-    this.awsConfig = options.awsConfig || AWS.config
+    this.awsConfig = options.auth || AWS.config
   }
 
   get credentials () {


### PR DESCRIPTION
bug in static mode - options.awsConfig not accessible in AmazonConnection constructor - possible use of auth to store AWS credentials as it is passed along Connection constructor by @elastic/elasticsearch Client